### PR TITLE
Fix GitHub repository link

### DIFF
--- a/cphmd_tutorial.tex
+++ b/cphmd_tutorial.tex
@@ -29,8 +29,7 @@
 
 \newcommand{\versionnumber}{1.0}  
 % you should update the minor version number in preprints and major version number of submissions.
-\newcommand{\githubrepository}{\url{
-https://github.com/JanaShenLab/CpHMD-Tutorial}}  %this should be the main github repository for this article
+\newcommand{\githubrepository}{\url{https://github.com/JanaShenLab/CpHMD-Tutorial}}  %this should be the main github repository for this article
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% ARTICLE SETUP


### PR DESCRIPTION
When there's a carriage return in the \url in the \githubrepository definition, it breaks the link in the PDF.